### PR TITLE
Rename plugin from continue to skdev

### DIFF
--- a/extensions/intellij/README.md
+++ b/extensions/intellij/README.md
@@ -1,10 +1,10 @@
 <!-- Plugin description -->
 
-<h1 align="center">Continue</h1>
+<h1 align="center">skdev</h1>
 
 <div align="center">
 
-[**Continue**](https://docs.continue.dev) is the leading open-source AI code assistant.
+[**skdev**](https://docs.continue.dev) is the leading open-source AI code assistant.
 
 You can connect any models and any context to build custom autocomplete and chat experiences inside [**VS Code**](https://marketplace.visualstudio.com/items?itemName=Continue.continue) and [**JetBrains**](https://plugins.jetbrains.com/plugin/22707-continue-extension) IDEs.
 

--- a/extensions/intellij/gradle.properties
+++ b/extensions/intellij/gradle.properties
@@ -1,9 +1,9 @@
 # IntelliJ Platform Artifacts Repositories -> https://plugins.jetbrains.com/docs/intellij/intellij-artifacts.html
-pluginGroup=com.github.continuedev.continueintellijextension
-pluginName=continue-intellij-extension
+pluginGroup=com.github.skdev.skdevintellijextension
+pluginName=skdev-intellij-extension
 pluginRepositoryUrl=https://github.com/continuedev/continue
 # SemVer format -> https://semver.org
-pluginVersion=0.0.89
+pluginVersion=0.0.1
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild=223
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension

--- a/extensions/intellij/settings.gradle.kts
+++ b/extensions/intellij/settings.gradle.kts
@@ -1,1 +1,1 @@
-rootProject.name = "continue-intellij-extension"
+rootProject.name = "skdev-intellij-extension"

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/actions/ContinuePluginActions.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/actions/ContinuePluginActions.kt
@@ -1,7 +1,7 @@
-package com.github.continuedev.continueintellijextension.actions
+package com.github.skdev.skdevintellijextension.actions
 
-import com.github.continuedev.continueintellijextension.editor.DiffStreamService
-import com.github.continuedev.continueintellijextension.services.ContinuePluginService
+import com.github.skdev.skdevintellijextension.editor.DiffStreamService
+import com.github.skdev.skdevintellijextension.services.ContinuePluginService
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.PlatformDataKeys

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/activities/ContinuePluginStartupActivity.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/activities/ContinuePluginStartupActivity.kt
@@ -1,16 +1,16 @@
-package com.github.continuedev.continueintellijextension.activities
+package com.github.skdev.skdevintellijextension.activities
 
 import IntelliJIDE
-import com.github.continuedev.continueintellijextension.auth.AuthListener
-import com.github.continuedev.continueintellijextension.auth.ContinueAuthService
-import com.github.continuedev.continueintellijextension.auth.ControlPlaneSessionInfo
-import com.github.continuedev.continueintellijextension.constants.getContinueGlobalPath
-import com.github.continuedev.continueintellijextension.`continue`.*
-import com.github.continuedev.continueintellijextension.listeners.ContinuePluginSelectionListener
-import com.github.continuedev.continueintellijextension.services.ContinueExtensionSettings
-import com.github.continuedev.continueintellijextension.services.ContinuePluginService
-import com.github.continuedev.continueintellijextension.services.SettingsListener
-import com.github.continuedev.continueintellijextension.utils.toUriOrNull
+import com.github.skdev.skdevintellijextension.auth.AuthListener
+import com.github.skdev.skdevintellijextension.auth.ContinueAuthService
+import com.github.skdev.skdevintellijextension.auth.ControlPlaneSessionInfo
+import com.github.skdev.skdevintellijextension.constants.getContinueGlobalPath
+import com.github.skdev.skdevintellijextension.`continue`.*
+import com.github.skdev.skdevintellijextension.listeners.ContinuePluginSelectionListener
+import com.github.skdev.skdevintellijextension.services.ContinueExtensionSettings
+import com.github.skdev.skdevintellijextension.services.ContinuePluginService
+import com.github.skdev.skdevintellijextension.services.SettingsListener
+import com.github.skdev.skdevintellijextension.utils.toUriOrNull
 import com.intellij.openapi.actionSystem.KeyboardShortcut
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ApplicationNamesInfo

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/auth/ContinueAuthService.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/auth/ContinueAuthService.kt
@@ -1,7 +1,7 @@
-package com.github.continuedev.continueintellijextension.auth
+package com.github.skdev.skdevintellijextension.auth
 
-import com.github.continuedev.continueintellijextension.services.ContinueExtensionSettings
-import com.github.continuedev.continueintellijextension.services.ContinuePluginService
+import com.github.skdev.skdevintellijextension.services.ContinueExtensionSettings
+import com.github.skdev.skdevintellijextension.services.ContinuePluginService
 import com.google.gson.Gson
 import com.intellij.credentialStore.Credentials
 import com.intellij.ide.passwordSafe.PasswordSafe

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/autocomplete/AutocompleteActionGroup.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/autocomplete/AutocompleteActionGroup.kt
@@ -1,6 +1,6 @@
-package com.github.continuedev.continueintellijextension.autocomplete
+package com.github.skdev.skdevintellijextension.autocomplete
 
-import com.github.continuedev.continueintellijextension.services.ContinueExtensionSettings
+import com.github.skdev.skdevintellijextension.services.ContinueExtensionSettings
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.DefaultActionGroup

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/CoreMessengerManager.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/CoreMessengerManager.kt
@@ -1,7 +1,7 @@
-package com.github.continuedev.continueintellijextension.`continue`
+package com.github.skdev.skdevintellijextension.`continue`
 
-import com.github.continuedev.continueintellijextension.services.TelemetryService
-import com.github.continuedev.continueintellijextension.utils.getMachineUniqueID
+import com.github.skdev.skdevintellijextension.services.TelemetryService
+import com.github.skdev.skdevintellijextension.utils.getMachineUniqueID
 import com.intellij.ide.plugins.PluginManager
 import com.intellij.openapi.components.service
 import com.intellij.openapi.extensions.PluginId

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/editor/DiffStreamHandler.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/editor/DiffStreamHandler.kt
@@ -1,6 +1,6 @@
-package com.github.continuedev.continueintellijextension.editor
+package com.github.skdev.skdevintellijextension.editor
 
-import com.github.continuedev.continueintellijextension.services.ContinuePluginService
+import com.github.skdev.skdevintellijextension.services.ContinuePluginService
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.command.undo.UndoManager

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/services/ContinueExtensionSettingsService.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/services/ContinueExtensionSettingsService.kt
@@ -1,7 +1,7 @@
-package com.github.continuedev.continueintellijextension.services
+package com.github.skdev.skdevintellijextension.services
 
-import com.github.continuedev.continueintellijextension.constants.getConfigJsPath
-import com.github.continuedev.continueintellijextension.constants.getConfigJsonPath
+import com.github.skdev.skdevintellijextension.constants.getConfigJsPath
+import com.github.skdev.skdevintellijextension.constants.getConfigJsonPath
 import com.intellij.execution.target.value.constant
 import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.application.ApplicationManager
@@ -85,7 +85,7 @@ class ContinueRemoteConfigSyncResponse {
 }
 
 @State(
-    name = "com.github.continuedev.continueintellijextension.services.ContinueExtensionSettings",
+    name = "com.github.skdev.skdevintellijextension.services.ContinueExtensionSettings",
     storages = [Storage("ContinueExtensionSettings.xml")]
 )
 open class ContinueExtensionSettings : PersistentStateComponent<ContinueExtensionSettings.ContinueState> {

--- a/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/services/ContinuePluginService.kt
+++ b/extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/services/ContinuePluginService.kt
@@ -1,12 +1,12 @@
-package com.github.continuedev.continueintellijextension.services
+package com.github.skdev.skdevintellijextension.services
 
 import IntelliJIDE
-import com.github.continuedev.continueintellijextension.`continue`.CoreMessenger
-import com.github.continuedev.continueintellijextension.`continue`.CoreMessengerManager
-import com.github.continuedev.continueintellijextension.`continue`.DiffManager
-import com.github.continuedev.continueintellijextension.`continue`.IdeProtocolClient
-import com.github.continuedev.continueintellijextension.toolWindow.ContinuePluginToolWindowFactory
-import com.github.continuedev.continueintellijextension.utils.uuid
+import com.github.skdev.skdevintellijextension.`continue`.CoreMessenger
+import com.github.skdev.skdevintellijextension.`continue`.CoreMessengerManager
+import com.github.skdev.skdevintellijextension.`continue`.DiffManager
+import com.github.skdev.skdevintellijextension.`continue`.IdeProtocolClient
+import com.github.skdev.skdevintellijextension.toolWindow.ContinuePluginToolWindowFactory
+import com.github.skdev.skdevintellijextension.utils.uuid
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.project.DumbAware

--- a/extensions/intellij/src/main/resources/META-INF/plugin.xml
+++ b/extensions/intellij/src/main/resources/META-INF/plugin.xml
@@ -1,8 +1,8 @@
 <!-- Plugin Configuration File. Read more: https://plugins.jetbrains.com/docs/intellij/plugin-configuration-file.html -->
 <idea-plugin>
-    <id>com.github.continuedev.continueintellijextension</id>
-    <name>Continue</name>
-    <vendor url="https://www.continue.dev/">continue-dev</vendor>
+    <id>com.github.skdev.skdevintellijextension</id>
+    <name>skdev</name>
+    <vendor url="https://www.continue.dev/">skdev</vendor>
     <change-notes>
         <![CDATA[View the latest release notes on <a href="https://github.com/continuedev/continue/releases">GitHub</a>]]></change-notes>
 


### PR DESCRIPTION
Rename the plugin name from 'continue' to 'skdev' and update the group name to 'com.github.skdev'. Reset the plugin version to 0.0.1.

* Update `extensions/intellij/gradle.properties` to change `pluginGroup` to `com.github.skdev.skdevintellijextension`, `pluginName` to `skdev-intellij-extension`, and reset `pluginVersion` to `0.0.1`.
* Modify `extensions/intellij/src/main/resources/META-INF/plugin.xml` to update `<id>` to `com.github.skdev.skdevintellijextension`, `<name>` to `skdev`, and `<vendor>` to `skdev`.
* Change `extensions/intellij/settings.gradle.kts` to update `rootProject.name` to `skdev-intellij-extension`.
* Update `extensions/intellij/README.md` to reference 'skdev' instead of 'continue'.
* Modify `extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/actions/ContinuePluginActions.kt` to update the package name to `com.github.skdev.skdevintellijextension.actions`.
* Change `extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/activities/ContinuePluginStartupActivity.kt` to update the package name to `com.github.skdev.skdevintellijextension.activities`.
* Update `extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/auth/ContinueAuthService.kt` to change the package name to `com.github.skdev.skdevintellijextension.auth`.
* Modify `extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/autocomplete/AutocompleteActionGroup.kt` to update the package name to `com.github.skdev.skdevintellijextension.autocomplete`.
* Change `extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/continue/CoreMessengerManager.kt` to update the package name to `com.github.skdev.skdevintellijextension.continue`.
* Update `extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/editor/DiffStreamHandler.kt` to change the package name to `com.github.skdev.skdevintellijextension.editor`.
* Modify `extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/services/ContinueExtensionSettingsService.kt` to update the package name to `com.github.skdev.skdevintellijextension.services`.
* Change `extensions/intellij/src/main/kotlin/com/github/continuedev/continueintellijextension/services/ContinuePluginService.kt` to update the package name to `com.github.skdev.skdevintellijextension.services`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/santhoshkumar-sn-7134/continue/pull/2?shareId=69265f02-66b1-4057-889f-13efdf9d34d6).